### PR TITLE
feat: restyle Task Sync workflow with shadcn components

### DIFF
--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,38 @@
+import { HTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+type AlertVariant = 'default' | 'info' | 'destructive';
+
+const variantClasses: Record<AlertVariant, string> = {
+  default: 'border-zinc-800/70 bg-zinc-900/70 text-zinc-200',
+  info: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
+  destructive: 'border-red-500/40 bg-red-500/10 text-red-200',
+};
+
+interface AlertProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: AlertVariant;
+}
+
+function Alert({ className, variant = 'default', ...props }: AlertProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'relative w-full overflow-hidden rounded-xl border px-4 py-3 text-sm shadow-[0_10px_30px_-20px_rgba(0,0,0,0.8)]',
+        variantClasses[variant],
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('text-sm font-semibold tracking-wide uppercase', className)} {...props} />;
+}
+
+function AlertDescription({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('text-sm leading-relaxed text-inherit', className)} {...props} />;
+}
+
+export { Alert, AlertTitle, AlertDescription };

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,28 @@
+import { HTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+type BadgeVariant = 'default' | 'secondary';
+
+const variantClasses: Record<BadgeVariant, string> = {
+  default: 'bg-emerald-500/90 text-zinc-950',
+  secondary: 'bg-zinc-800 text-zinc-200',
+};
+
+interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+function Badge({ className, variant = 'default', ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium uppercase tracking-wide',
+        variantClasses[variant],
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Badge };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,51 @@
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+import { cn } from '../../lib/utils';
+
+type ButtonVariant = 'default' | 'secondary' | 'outline' | 'ghost' | 'destructive';
+type ButtonSize = 'default' | 'sm' | 'lg' | 'icon';
+
+const variantClasses: Record<ButtonVariant, string> = {
+  default:
+    'bg-emerald-500 text-zinc-950 hover:bg-emerald-400 focus-visible:ring-2 focus-visible:ring-emerald-300',
+  secondary:
+    'bg-zinc-800 text-zinc-100 hover:bg-zinc-700 focus-visible:ring-2 focus-visible:ring-zinc-500/50',
+  outline:
+    'border border-zinc-700 text-zinc-100 hover:bg-zinc-800/70 focus-visible:ring-2 focus-visible:ring-zinc-500/40',
+  ghost: 'text-zinc-300 hover:bg-zinc-800/60 focus-visible:ring-2 focus-visible:ring-zinc-500/30',
+  destructive:
+    'bg-red-500 text-white hover:bg-red-400 focus-visible:ring-2 focus-visible:ring-red-300 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  default: 'h-10 px-4 py-2 text-sm font-medium',
+  sm: 'h-9 px-3 text-xs font-medium',
+  lg: 'h-11 px-6 text-base font-semibold',
+  icon: 'h-10 w-10 flex items-center justify-center',
+};
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'default', type = 'button', ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(
+          'inline-flex items-center justify-center rounded-lg transition-colors focus-visible:outline-none focus-visible:ring disabled:pointer-events-none disabled:opacity-50',
+          variantClasses[variant],
+          sizeClasses[size],
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Button.displayName = 'Button';
+
+export { Button };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,36 @@
+import { HTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border border-zinc-800/80 bg-zinc-950/70 shadow-[0_20px_45px_-25px_rgba(0,0,0,0.7)] backdrop-blur-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex flex-col gap-1.5 p-6 pb-0', className)} {...props} />;
+}
+
+function CardTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn('text-lg font-semibold text-zinc-100', className)} {...props} />;
+}
+
+function CardDescription({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('text-sm text-zinc-400', className)} {...props} />;
+}
+
+function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('p-6 pt-4', className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex items-center justify-between gap-2 p-6 pt-0 text-sm', className)} {...props} />;
+}
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import { InputHTMLAttributes, forwardRef } from 'react';
+import { cn } from '../../lib/utils';
+
+type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+const Input = forwardRef<HTMLInputElement, InputProps>(({ className, type = 'text', ...props }, ref) => {
+  return (
+    <input
+      ref={ref}
+      type={type}
+      className={cn(
+        'flex h-11 w-full rounded-xl border border-zinc-800/70 bg-zinc-900/60 px-4 text-sm text-zinc-100 placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40 disabled:cursor-not-allowed disabled:opacity-60',
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+Input.displayName = 'Input';
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,8 @@
+import { LabelHTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+function Label({ className, ...props }: LabelHTMLAttributes<HTMLLabelElement>) {
+  return <label className={cn('text-sm font-medium text-zinc-300', className)} {...props} />;
+}
+
+export { Label };

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,28 @@
+import { HTMLAttributes, TableHTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+function Table({ className, ...props }: TableHTMLAttributes<HTMLTableElement>) {
+  return <table className={cn('w-full caption-bottom text-sm text-zinc-200', className)} {...props} />;
+}
+
+function TableHeader({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {
+  return <thead className={cn('bg-zinc-900/80 text-left text-xs uppercase tracking-wide text-zinc-400', className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={cn('divide-y divide-zinc-800/80 bg-zinc-950/60', className)} {...props} />;
+}
+
+function TableRow({ className, ...props }: HTMLAttributes<HTMLTableRowElement>) {
+  return <tr className={cn('transition-colors hover:bg-zinc-900/60', className)} {...props} />;
+}
+
+function TableHead({ className, ...props }: HTMLAttributes<HTMLTableCellElement>) {
+  return <th className={cn('px-4 py-3 font-medium', className)} {...props} />;
+}
+
+function TableCell({ className, ...props }: HTMLAttributes<HTMLTableCellElement>) {
+  return <td className={cn('px-4 py-3 align-middle text-sm text-zinc-100', className)} {...props} />;
+}
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };

--- a/src/features/taskSync/components/ExcelUploadCard.tsx
+++ b/src/features/taskSync/components/ExcelUploadCard.tsx
@@ -59,37 +59,48 @@ export default function ExcelUploadCard({ setData }: Props) {
   }
 
   return (
-    <Card className="relative overflow-hidden border-zinc-800/60">
-      <div className="pointer-events-none absolute inset-x-10 top-0 h-px bg-gradient-to-r from-transparent via-emerald-500/60 to-transparent" />
-      <CardHeader>
-        <CardTitle>Importar tareas desde MQMS</CardTitle>
-        <CardDescription>
-          Carga el archivo Excel exportado desde MQMS para detectar tareas que aún no existen en ClickUp.
-        </CardDescription>
+    <Card className="relative overflow-hidden border-slate-800/70 bg-slate-900/70">
+      <div className="pointer-events-none absolute inset-x-10 top-0 h-px bg-gradient-to-r from-transparent via-emerald-400/70 to-transparent" />
+      <CardHeader className="space-y-5">
+        <div className="flex flex-wrap items-center gap-3 text-[0.65rem] uppercase tracking-[0.35em] text-emerald-300">
+          <span className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-400/40 bg-emerald-400/10 text-xs font-semibold text-emerald-200">
+            PASO 2
+          </span>
+          <span className="font-semibold tracking-[0.28em] text-emerald-200">Importa tu archivo</span>
+        </div>
+        <div className="space-y-2">
+          <CardTitle className="text-2xl font-semibold text-slate-50">Importar tareas desde MQMS</CardTitle>
+          <CardDescription className="text-sm text-slate-400">
+            Carga el archivo Excel exportado desde MQMS para detectar tareas que aún no existen en ClickUp.
+          </CardDescription>
+        </div>
       </CardHeader>
       <CardContent className="space-y-5">
         <div className="space-y-2">
-          <Label htmlFor="mqms-file">Archivo Excel (.xlsx o .xls)</Label>
+          <Label htmlFor="mqms-file" className="text-slate-200">
+            Archivo Excel (.xlsx o .xls)
+          </Label>
           <Input
             id="mqms-file"
             type="file"
             accept=".xlsx,.xls"
             onChange={e => setFile(e.target.files?.[0] ?? null)}
-            className="cursor-pointer border-dashed border-zinc-700/80 bg-zinc-950/40 file:mr-4 file:rounded-lg file:border-0 file:bg-emerald-500/90 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-zinc-900 hover:border-emerald-500/40"
+            className="cursor-pointer border-dashed border-slate-700/70 bg-slate-950/60 text-slate-200 file:mr-4 file:rounded-lg file:border-0 file:bg-emerald-400 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-slate-950 hover:border-emerald-400/60"
           />
         </div>
         {file && (
-          <Badge variant="secondary" className="w-fit">
+          <Badge variant="secondary" className="w-fit bg-slate-800/90 text-slate-100">
             {file.name}
           </Badge>
         )}
       </CardContent>
-      <CardFooter className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+      <CardFooter className="flex flex-col items-start gap-4 border-t border-slate-800/70 bg-slate-900/60 sm:flex-row sm:items-center">
         <Button onClick={handleProcessFile} disabled={!file || parsing} className="w-full sm:w-auto">
           {parsing ? 'Procesando archivo…' : 'Procesar archivo'}
         </Button>
-        <p className="text-xs leading-relaxed text-zinc-400">
-          Columnas requeridas: <span className="text-zinc-300">{DESIRED_KEYS.join(', ')}</span>
+        <p className="text-xs leading-relaxed text-slate-400">
+          Columnas requeridas:{' '}
+          <span className="text-slate-200">{DESIRED_KEYS.join(', ')}</span>
         </p>
       </CardFooter>
     </Card>

--- a/src/features/taskSync/components/ExcelUploadCard.tsx
+++ b/src/features/taskSync/components/ExcelUploadCard.tsx
@@ -1,5 +1,10 @@
 import { useState } from 'react';
 import * as XLSX from 'xlsx';
+import { Button } from '../../../components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../../../components/ui/card';
+import { Input } from '../../../components/ui/input';
+import { Label } from '../../../components/ui/label';
+import { Badge } from '../../../components/ui/badge';
 import type { MQMSTask, ParsedData } from '../../../types/Task';
 import { DESIRED_KEYS } from '../config/mqmsSchema';
 
@@ -46,7 +51,6 @@ export default function ExcelUploadCard({ setData }: Props) {
         if (obj[key] !== null && obj[key] !== undefined) {
           acc[key] = obj[key] as MQMSTask[typeof key];
         } else {
-          // Ensure key exists as empty string to keep strict typing and predictable rendering
           acc[key] = '' as MQMSTask[typeof key];
         }
         return acc;
@@ -55,27 +59,39 @@ export default function ExcelUploadCard({ setData }: Props) {
   }
 
   return (
-    <div className="w-full max-w-3xl mx-auto mb-6">
-      <div className="rounded-xl border border-zinc-800 p-4 bg-zinc-900/40">
-        <h2 className="text-lg font-semibold mb-3">Cargar Excel de MQMS</h2>
-        <div className="flex items-center gap-3">
-          <input
+    <Card className="relative overflow-hidden border-zinc-800/60">
+      <div className="pointer-events-none absolute inset-x-10 top-0 h-px bg-gradient-to-r from-transparent via-emerald-500/60 to-transparent" />
+      <CardHeader>
+        <CardTitle>Importar tareas desde MQMS</CardTitle>
+        <CardDescription>
+          Carga el archivo Excel exportado desde MQMS para detectar tareas que aún no existen en ClickUp.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="space-y-2">
+          <Label htmlFor="mqms-file">Archivo Excel (.xlsx o .xls)</Label>
+          <Input
+            id="mqms-file"
             type="file"
             accept=".xlsx,.xls"
             onChange={e => setFile(e.target.files?.[0] ?? null)}
-            className="block w-full text-sm text-zinc-300 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-zinc-800 file:text-white hover:file:bg-zinc-700"
+            className="cursor-pointer border-dashed border-zinc-700/80 bg-zinc-950/40 file:mr-4 file:rounded-lg file:border-0 file:bg-emerald-500/90 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-zinc-900 hover:border-emerald-500/40"
           />
-          <button
-            type="button"
-            disabled={!file || parsing}
-            onClick={handleProcessFile}
-            className="px-4 py-2 rounded-md bg-indigo-600 disabled:bg-zinc-700 disabled:cursor-not-allowed hover:bg-indigo-500 text-white text-sm"
-          >
-            {parsing ? 'Procesando…' : 'Procesar archivo'}
-          </button>
         </div>
-        <p className="mt-2 text-xs text-zinc-400">Columnas esperadas: {DESIRED_KEYS.join(', ')}</p>
-      </div>
-    </div>
+        {file && (
+          <Badge variant="secondary" className="w-fit">
+            {file.name}
+          </Badge>
+        )}
+      </CardContent>
+      <CardFooter className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+        <Button onClick={handleProcessFile} disabled={!file || parsing} className="w-full sm:w-auto">
+          {parsing ? 'Procesando archivo…' : 'Procesar archivo'}
+        </Button>
+        <p className="text-xs leading-relaxed text-zinc-400">
+          Columnas requeridas: <span className="text-zinc-300">{DESIRED_KEYS.join(', ')}</span>
+        </p>
+      </CardFooter>
+    </Card>
   );
 }

--- a/src/features/taskSync/components/ListSelector.tsx
+++ b/src/features/taskSync/components/ListSelector.tsx
@@ -1,4 +1,8 @@
 import { useMemo } from 'react';
+import { Button } from '../../../components/ui/button';
+import { Badge } from '../../../components/ui/badge';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../../../components/ui/card';
+import { cn } from '../../../lib/utils';
 import { CLICKUP_LIST_IDS } from '../../../utils/config';
 
 export type MainList = 'highsplit' | 'bau' | null;
@@ -12,6 +16,43 @@ interface Props {
   onListResolved: (listId: string | null) => void;
 }
 
+type OptionBase<TValue> = {
+  value: TValue;
+  label: string;
+  description: string;
+};
+
+const mainOptions: OptionBase<Exclude<MainList, null>>[] = [
+  {
+    value: 'highsplit',
+    label: 'High Split',
+    description: 'Proyectos CCI High Split: nuevos nodos y expansiones.',
+  },
+  {
+    value: 'bau',
+    label: 'BAU',
+    description: 'Operación diaria: tickets TrueNet, TechServ o CCI.',
+  },
+];
+
+const bauOptions: OptionBase<Exclude<BauType, null>>[] = [
+  {
+    value: 'cci',
+    label: 'CCI',
+    description: 'Construcción y mantenimiento para CCI.',
+  },
+  {
+    value: 'truenet',
+    label: 'TrueNet',
+    description: 'Seguimiento y QA de proyectos TrueNet.',
+  },
+  {
+    value: 'techserv',
+    label: 'TechServ',
+    description: 'Operación BAU para TechServ.',
+  },
+];
+
 export default function ListSelector({ main, setMain, bau, setBau, onListResolved }: Props) {
   const listId = useMemo(() => {
     if (main === 'highsplit') return CLICKUP_LIST_IDS.cciHs;
@@ -24,90 +65,91 @@ export default function ListSelector({ main, setMain, bau, setBau, onListResolve
   }, [main, bau]);
 
   return (
-    <div className="w-full max-w-3xl mx-auto">
-      <div className="rounded-xl border border-zinc-800 p-4 bg-zinc-900/40">
-        <h2 className="text-lg font-semibold mb-3">Selecciona la lista destino</h2>
-        <div className="flex gap-4">
-          <label className="inline-flex items-center gap-2">
-            <input
-              type="radio"
-              name="main"
-              value="highsplit"
-              checked={main === 'highsplit'}
-              onChange={() => {
-                setMain('highsplit');
-                setBau(null);
-                onListResolved(CLICKUP_LIST_IDS.cciHs);
-              }}
-            />
-            <span>High Split</span>
-          </label>
-          <label className="inline-flex items-center gap-2">
-            <input
-              type="radio"
-              name="main"
-              value="bau"
-              checked={main === 'bau'}
-              onChange={() => {
-                setMain('bau');
-                onListResolved(null);
-              }}
-            />
-            <span>BAU</span>
-          </label>
+    <Card className="border-zinc-800/70">
+      <CardHeader>
+        <CardTitle>Selecciona la lista destino</CardTitle>
+        <CardDescription>
+          Elige el flujo de ClickUp al que quieres sincronizar las tareas nuevas detectadas en el Excel de MQMS.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-8">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-widest text-zinc-500">Flujo principal</p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {mainOptions.map(option => {
+              const isActive = main === option.value;
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  variant={isActive ? 'default' : 'outline'}
+                  className={cn(
+                    'h-auto justify-start rounded-2xl border border-transparent px-5 py-4 text-left shadow-inner transition-all',
+                    'bg-gradient-to-br from-zinc-900/70 via-zinc-900/40 to-zinc-900/20',
+                    isActive
+                      ? 'ring-2 ring-emerald-400/60 shadow-[0_12px_45px_-28px_rgba(16,185,129,0.8)]'
+                      : 'hover:border-zinc-700 hover:shadow-[0_15px_35px_-30px_rgba(0,0,0,0.8)]'
+                  )}
+                  onClick={() => {
+                    setMain(option.value);
+                    if (option.value === 'highsplit') {
+                      setBau(null);
+                      onListResolved(CLICKUP_LIST_IDS.cciHs);
+                    } else {
+                      setBau(null);
+                      onListResolved(null);
+                    }
+                  }}
+                >
+                  <span className="text-sm font-semibold text-zinc-100">{option.label}</span>
+                  <span className="mt-1 block text-xs text-zinc-400">{option.description}</span>
+                </Button>
+              );
+            })}
+          </div>
         </div>
 
         {main === 'bau' && (
-          <div className="mt-4 space-y-2">
-            <p className="text-sm text-zinc-300">Seleccione el tipo de BAU:</p>
-            <div className="flex gap-4">
-              <label className="inline-flex items-center gap-2">
-                <input
-                  type="radio"
-                  name="bau"
-                  value="cci"
-                  checked={bau === 'cci'}
-                  onChange={() => {
-                    setBau('cci');
-                    onListResolved(CLICKUP_LIST_IDS.cciBau);
-                  }}
-                />
-                <span>CCI</span>
-              </label>
-              <label className="inline-flex items-center gap-2">
-                <input
-                  type="radio"
-                  name="bau"
-                  value="truenet"
-                  checked={bau === 'truenet'}
-                  onChange={() => {
-                    setBau('truenet');
-                    onListResolved(CLICKUP_LIST_IDS.trueNetBau);
-                  }}
-                />
-                <span>TrueNet</span>
-              </label>
-              <label className="inline-flex items-center gap-2">
-                <input
-                  type="radio"
-                  name="bau"
-                  value="techserv"
-                  checked={bau === 'techserv'}
-                  onChange={() => {
-                    setBau('techserv');
-                    onListResolved(CLICKUP_LIST_IDS.techservBau);
-                  }}
-                />
-                <span>TechServ</span>
-              </label>
+          <div className="space-y-3">
+            <p className="text-xs uppercase tracking-widest text-zinc-500">Tipo de BAU</p>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {bauOptions.map(option => {
+                const isActive = bau === option.value;
+                return (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    variant={isActive ? 'default' : 'outline'}
+                    className={cn(
+                      'h-auto justify-start rounded-2xl border border-transparent px-4 py-4 text-left shadow-inner transition-all',
+                      'bg-zinc-950/40',
+                      isActive
+                        ? 'ring-2 ring-emerald-400/50'
+                        : 'hover:border-zinc-700 hover:bg-zinc-900/50'
+                    )}
+                    onClick={() => {
+                      setBau(option.value);
+                      if (option.value === 'cci') onListResolved(CLICKUP_LIST_IDS.cciBau);
+                      if (option.value === 'truenet') onListResolved(CLICKUP_LIST_IDS.trueNetBau);
+                      if (option.value === 'techserv') onListResolved(CLICKUP_LIST_IDS.techservBau);
+                    }}
+                  >
+                    <span className="text-sm font-semibold text-zinc-100">{option.label}</span>
+                    <span className="mt-1 block text-xs text-zinc-400">{option.description}</span>
+                  </Button>
+                );
+              })}
             </div>
           </div>
         )}
-
-        <div className="mt-4 text-sm text-zinc-400">
-          {listId ? 'Listo para sincronizar.' : 'Seleccione una lista y (si aplica) un tipo de BAU.'}
+      </CardContent>
+      <CardFooter className="flex flex-col items-start gap-3 text-sm text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Badge variant={listId ? 'default' : 'secondary'}>{listId ? 'Listo para sincronizar' : 'Selecciona una lista'}</Badge>
+          <span className="text-xs text-zinc-500">{main === 'bau' ? 'BAU requiere un subtipo.' : 'High Split se resuelve automáticamente.'}</span>
         </div>
-      </div>
-    </div>
+        {listId && <span className="text-xs text-zinc-500">ID seleccionado: {listId}</span>}
+      </CardFooter>
+    </Card>
   );
 }

--- a/src/features/taskSync/components/ListSelector.tsx
+++ b/src/features/taskSync/components/ListSelector.tsx
@@ -65,17 +65,25 @@ export default function ListSelector({ main, setMain, bau, setBau, onListResolve
   }, [main, bau]);
 
   return (
-    <Card className="border-zinc-800/70">
-      <CardHeader>
-        <CardTitle>Selecciona la lista destino</CardTitle>
-        <CardDescription>
-          Elige el flujo de ClickUp al que quieres sincronizar las tareas nuevas detectadas en el Excel de MQMS.
-        </CardDescription>
+    <Card className="border-slate-800/80 bg-slate-900/70 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.75)] backdrop-blur">
+      <CardHeader className="space-y-6">
+        <div className="flex flex-wrap items-center gap-3 text-[0.65rem] uppercase tracking-[0.35em] text-emerald-300">
+          <span className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-400/40 bg-emerald-400/10 text-xs font-semibold text-emerald-200">
+            PASO 1
+          </span>
+          <span className="font-semibold tracking-[0.28em] text-emerald-200">Selecciona el flujo destino</span>
+        </div>
+        <div className="space-y-2">
+          <CardTitle className="text-2xl font-semibold text-slate-50">Selecciona la lista destino</CardTitle>
+          <CardDescription className="text-sm text-slate-400">
+            Elige el flujo de ClickUp al que quieres sincronizar las tareas nuevas detectadas en el Excel de MQMS.
+          </CardDescription>
+        </div>
       </CardHeader>
-      <CardContent className="space-y-8">
-        <div className="space-y-3">
-          <p className="text-xs uppercase tracking-widest text-zinc-500">Flujo principal</p>
-          <div className="grid gap-3 sm:grid-cols-2">
+      <CardContent className="space-y-10">
+        <div className="space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-500">Flujo principal</p>
+          <div className="grid gap-4 sm:grid-cols-2">
             {mainOptions.map(option => {
               const isActive = main === option.value;
               return (
@@ -84,11 +92,10 @@ export default function ListSelector({ main, setMain, bau, setBau, onListResolve
                   type="button"
                   variant={isActive ? 'default' : 'outline'}
                   className={cn(
-                    'h-auto justify-start rounded-2xl border border-transparent px-5 py-4 text-left shadow-inner transition-all',
-                    'bg-gradient-to-br from-zinc-900/70 via-zinc-900/40 to-zinc-900/20',
+                    'group h-auto flex-col items-start justify-start gap-2 rounded-2xl border border-slate-800 bg-slate-950/60 px-6 py-5 text-left shadow-[0_12px_30px_-20px_rgba(15,23,42,0.8)] transition-all',
                     isActive
-                      ? 'ring-2 ring-emerald-400/60 shadow-[0_12px_45px_-28px_rgba(16,185,129,0.8)]'
-                      : 'hover:border-zinc-700 hover:shadow-[0_15px_35px_-30px_rgba(0,0,0,0.8)]'
+                      ? 'border-emerald-400/80 bg-emerald-500/10 ring-2 ring-emerald-400/40'
+                      : 'hover:border-slate-700 hover:bg-slate-900/60 hover:shadow-[0_25px_45px_-32px_rgba(16,185,129,0.55)]'
                   )}
                   onClick={() => {
                     setMain(option.value);
@@ -101,8 +108,22 @@ export default function ListSelector({ main, setMain, bau, setBau, onListResolve
                     }
                   }}
                 >
-                  <span className="text-sm font-semibold text-zinc-100">{option.label}</span>
-                  <span className="mt-1 block text-xs text-zinc-400">{option.description}</span>
+                  <span className="inline-flex items-center gap-3 text-sm font-semibold text-slate-100">
+                    <span
+                      className={cn(
+                        'flex h-9 w-9 items-center justify-center rounded-full border text-xs font-semibold transition-colors',
+                        isActive
+                          ? 'border-emerald-300 bg-emerald-400/20 text-emerald-100'
+                          : 'border-slate-700 bg-slate-900/70 text-slate-400'
+                      )}
+                    >
+                      {option.label.charAt(0)}
+                    </span>
+                    {option.label}
+                  </span>
+                  <span className="block text-xs text-slate-400 transition-colors group-hover:text-slate-300">
+                    {option.description}
+                  </span>
                 </Button>
               );
             })}
@@ -110,9 +131,9 @@ export default function ListSelector({ main, setMain, bau, setBau, onListResolve
         </div>
 
         {main === 'bau' && (
-          <div className="space-y-3">
-            <p className="text-xs uppercase tracking-widest text-zinc-500">Tipo de BAU</p>
-            <div className="grid gap-3 sm:grid-cols-3">
+          <div className="space-y-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-500">Tipo de BAU</p>
+            <div className="grid gap-4 sm:grid-cols-3">
               {bauOptions.map(option => {
                 const isActive = bau === option.value;
                 return (
@@ -121,11 +142,10 @@ export default function ListSelector({ main, setMain, bau, setBau, onListResolve
                     type="button"
                     variant={isActive ? 'default' : 'outline'}
                     className={cn(
-                      'h-auto justify-start rounded-2xl border border-transparent px-4 py-4 text-left shadow-inner transition-all',
-                      'bg-zinc-950/40',
+                      'group h-auto flex-col items-start justify-start gap-2 rounded-2xl border border-slate-800 bg-slate-950/60 px-5 py-4 text-left transition-all',
                       isActive
-                        ? 'ring-2 ring-emerald-400/50'
-                        : 'hover:border-zinc-700 hover:bg-zinc-900/50'
+                        ? 'border-emerald-400/70 bg-emerald-500/10 ring-1 ring-emerald-400/40'
+                        : 'hover:border-slate-700 hover:bg-slate-900/60'
                     )}
                     onClick={() => {
                       setBau(option.value);
@@ -134,8 +154,10 @@ export default function ListSelector({ main, setMain, bau, setBau, onListResolve
                       if (option.value === 'techserv') onListResolved(CLICKUP_LIST_IDS.techservBau);
                     }}
                   >
-                    <span className="text-sm font-semibold text-zinc-100">{option.label}</span>
-                    <span className="mt-1 block text-xs text-zinc-400">{option.description}</span>
+                    <span className="text-sm font-semibold text-slate-100">{option.label}</span>
+                    <span className="block text-xs text-slate-400 transition-colors group-hover:text-slate-300">
+                      {option.description}
+                    </span>
                   </Button>
                 );
               })}
@@ -143,12 +165,19 @@ export default function ListSelector({ main, setMain, bau, setBau, onListResolve
           </div>
         )}
       </CardContent>
-      <CardFooter className="flex flex-col items-start gap-3 text-sm text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <Badge variant={listId ? 'default' : 'secondary'}>{listId ? 'Listo para sincronizar' : 'Selecciona una lista'}</Badge>
-          <span className="text-xs text-zinc-500">{main === 'bau' ? 'BAU requiere un subtipo.' : 'High Split se resuelve automáticamente.'}</span>
+      <CardFooter className="flex flex-col gap-3 border-t border-slate-800/70 bg-slate-900/60 px-6 py-5 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-3">
+          <Badge
+            variant={listId ? 'default' : 'secondary'}
+            className={cn(listId ? 'bg-emerald-400/90 text-slate-950' : 'bg-slate-800/90 text-slate-200')}
+          >
+            {listId ? 'Listo para sincronizar' : 'Selecciona una lista'}
+          </Badge>
+          <span className="text-xs text-slate-500">
+            {main === 'bau' ? 'BAU requiere un subtipo.' : 'High Split se resuelve automáticamente.'}
+          </span>
         </div>
-        {listId && <span className="text-xs text-zinc-500">ID seleccionado: {listId}</span>}
+        {listId && <span className="text-xs text-slate-500">ID seleccionado: {listId}</span>}
       </CardFooter>
     </Card>
   );

--- a/src/features/taskSync/components/NewTasksTableV2.tsx
+++ b/src/features/taskSync/components/NewTasksTableV2.tsx
@@ -30,8 +30,8 @@ export default function NewTasksTableV2({ rows, onSyncOne }: Props) {
         accessorKey: 'JOB_NAME',
         cell: ({ getValue, row }) => (
           <div className="space-y-1">
-            <p className="font-medium text-zinc-50">{getValue<string>() || 'Sin nombre'}</p>
-            <p className="text-xs text-zinc-400">Nodo: {row.original.NODE_NAME || 'N/A'}</p>
+            <p className="font-semibold text-slate-100">{getValue<string>() || 'Sin nombre'}</p>
+            <p className="text-xs text-slate-400">Nodo: {row.original.NODE_NAME || 'N/A'}</p>
           </div>
         ),
       },
@@ -40,9 +40,13 @@ export default function NewTasksTableV2({ rows, onSyncOne }: Props) {
         accessorKey: 'EXTERNAL_ID',
         cell: ({ getValue, row }) => (
           <div className="flex flex-wrap gap-2">
-            <Badge variant="secondary">{getValue<string>() || '—'}</Badge>
+            <Badge variant="secondary" className="bg-slate-800/80 text-slate-100">
+              {getValue<string>() || '—'}
+            </Badge>
             {row.original.SECONDARY_EXTERNAL_ID && (
-              <Badge variant="secondary">{row.original.SECONDARY_EXTERNAL_ID}</Badge>
+              <Badge variant="secondary" className="bg-slate-800/80 text-slate-100">
+                {row.original.SECONDARY_EXTERNAL_ID}
+              </Badge>
             )}
           </div>
         ),
@@ -52,8 +56,8 @@ export default function NewTasksTableV2({ rows, onSyncOne }: Props) {
         accessorKey: 'REQUEST_NAME',
         cell: ({ getValue, row }) => (
           <div className="space-y-1">
-            <p>{getValue<string>() || 'Sin descripción'}</p>
-            <p className="text-xs text-zinc-500">WR ID: {row.original.REQUEST_ID || 'N/A'}</p>
+            <p className="text-slate-200">{getValue<string>() || 'Sin descripción'}</p>
+            <p className="text-xs text-slate-500">WR ID: {row.original.REQUEST_ID || 'N/A'}</p>
           </div>
         ),
       },
@@ -61,7 +65,7 @@ export default function NewTasksTableV2({ rows, onSyncOne }: Props) {
         header: 'Proyecto',
         accessorKey: 'PROJECT_TYPE',
         cell: ({ getValue }) => (
-          <Badge variant="default" className="bg-emerald-500/80 text-zinc-950">
+          <Badge variant="default" className="bg-emerald-400/90 text-slate-950">
             {getValue<string>() || 'Sin tipo'}
           </Badge>
         ),
@@ -70,7 +74,7 @@ export default function NewTasksTableV2({ rows, onSyncOne }: Props) {
         header: 'Hub',
         accessorKey: 'HUB',
         cell: ({ getValue }) => (
-          <Badge variant="secondary" className="bg-zinc-800/80">
+          <Badge variant="secondary" className="bg-slate-800/80 text-slate-200">
             {getValue<string>() || 'N/A'}
           </Badge>
         ),
@@ -82,7 +86,7 @@ export default function NewTasksTableV2({ rows, onSyncOne }: Props) {
           <Button
             type="button"
             size="sm"
-            variant="secondary"
+            className="bg-emerald-500 text-slate-950 hover:bg-emerald-400"
             onClick={() => onSyncOne(row.original.EXTERNAL_ID)}
           >
             Sincronizar
@@ -100,7 +104,7 @@ export default function NewTasksTableV2({ rows, onSyncOne }: Props) {
   });
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-zinc-800/60">
+    <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/60">
       <div className="overflow-x-auto">
         <Table>
           <TableHeader>

--- a/src/features/taskSync/components/NewTasksTableV2.tsx
+++ b/src/features/taskSync/components/NewTasksTableV2.tsx
@@ -1,4 +1,14 @@
 import { useMemo } from 'react';
+import { Button } from '../../../components/ui/button';
+import { Badge } from '../../../components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../../components/ui/table';
 import type { MQMSTask } from '../../../types/Task';
 import {
   ColumnDef,
@@ -15,25 +25,68 @@ interface Props {
 export default function NewTasksTableV2({ rows, onSyncOne }: Props) {
   const columns = useMemo<ColumnDef<MQMSTask, unknown>[]>(
     () => [
-      { header: 'JOB_NAME', accessorKey: 'JOB_NAME' },
-      { header: 'EXTERNAL_ID', accessorKey: 'EXTERNAL_ID' },
-      { header: 'SECONDARY_EXTERNAL_ID', accessorKey: 'SECONDARY_EXTERNAL_ID' },
-      { header: 'REQUEST_NAME', accessorKey: 'REQUEST_NAME' },
-      { header: 'PROJECT_TYPE', accessorKey: 'PROJECT_TYPE' },
-      { header: 'NODE_NAME', accessorKey: 'NODE_NAME' },
-      { header: 'REQUEST_ID', accessorKey: 'REQUEST_ID' },
-      { header: 'HUB', accessorKey: 'HUB' },
+      {
+        header: 'Job',
+        accessorKey: 'JOB_NAME',
+        cell: ({ getValue, row }) => (
+          <div className="space-y-1">
+            <p className="font-medium text-zinc-50">{getValue<string>() || 'Sin nombre'}</p>
+            <p className="text-xs text-zinc-400">Nodo: {row.original.NODE_NAME || 'N/A'}</p>
+          </div>
+        ),
+      },
+      {
+        header: 'IDs externos',
+        accessorKey: 'EXTERNAL_ID',
+        cell: ({ getValue, row }) => (
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="secondary">{getValue<string>() || '—'}</Badge>
+            {row.original.SECONDARY_EXTERNAL_ID && (
+              <Badge variant="secondary">{row.original.SECONDARY_EXTERNAL_ID}</Badge>
+            )}
+          </div>
+        ),
+      },
+      {
+        header: 'Request',
+        accessorKey: 'REQUEST_NAME',
+        cell: ({ getValue, row }) => (
+          <div className="space-y-1">
+            <p>{getValue<string>() || 'Sin descripción'}</p>
+            <p className="text-xs text-zinc-500">WR ID: {row.original.REQUEST_ID || 'N/A'}</p>
+          </div>
+        ),
+      },
+      {
+        header: 'Proyecto',
+        accessorKey: 'PROJECT_TYPE',
+        cell: ({ getValue }) => (
+          <Badge variant="default" className="bg-emerald-500/80 text-zinc-950">
+            {getValue<string>() || 'Sin tipo'}
+          </Badge>
+        ),
+      },
+      {
+        header: 'Hub',
+        accessorKey: 'HUB',
+        cell: ({ getValue }) => (
+          <Badge variant="secondary" className="bg-zinc-800/80">
+            {getValue<string>() || 'N/A'}
+          </Badge>
+        ),
+      },
       {
         id: 'actions',
         header: 'Acciones',
         cell: ({ row }) => (
-          <button
+          <Button
             type="button"
-            className="px-2 py-1 rounded-md bg-indigo-600 hover:bg-indigo-500 text-white text-xs"
+            size="sm"
+            variant="secondary"
             onClick={() => onSyncOne(row.original.EXTERNAL_ID)}
           >
-            Sync
-          </button>
+            Sincronizar
+          </Button>
         ),
       },
     ],
@@ -47,33 +100,35 @@ export default function NewTasksTableV2({ rows, onSyncOne }: Props) {
   });
 
   return (
-    <div className="rounded-xl border border-zinc-800 overflow-hidden">
-      <table className="w-full text-sm">
-        <thead className="bg-zinc-900 text-zinc-200">
-          {table.getHeaderGroups().map(headerGroup => (
-            <tr key={headerGroup.id}>
-              {headerGroup.headers.map(header => (
-                <th key={header.id} className="px-3 py-2 text-left font-medium">
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(header.column.columnDef.header, header.getContext())}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody className="divide-y divide-zinc-800 bg-zinc-950">
-          {table.getRowModel().rows.map(row => (
-            <tr key={row.id} className="hover:bg-zinc-900/60">
-              {row.getVisibleCells().map(cell => (
-                <td key={cell.id} className="px-3 py-2 text-zinc-200">
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="overflow-hidden rounded-2xl border border-zinc-800/60">
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map(headerGroup => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map(header => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.map(row => (
+              <TableRow key={row.id}>
+                {row.getVisibleCells().map(cell => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     </div>
   );
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | undefined | null | false>): string {
+  return classes.filter(Boolean).join(' ');
+}

--- a/src/pages/MqmsVerification/SyncTimetracking/TimetrackingTable.functions.ts
+++ b/src/pages/MqmsVerification/SyncTimetracking/TimetrackingTable.functions.ts
@@ -1,8 +1,4 @@
-import {
-  CreateNewTimeEntryResponse,
-  newTimeEntryPayload,
-  TimetrackingPayload,
-} from '../../../types/Task';
+import { CreateNewTimeEntryResponse, TimetrackingPayload } from '../../../types/Task';
 import { createNewtimeEntry } from '../../../utils/clickUpApi';
 import { sendBatchedRequests } from '../../../utils/helperFunctions';
 

--- a/src/pages/TaskSync/TaskSync.tsx
+++ b/src/pages/TaskSync/TaskSync.tsx
@@ -1,7 +1,10 @@
 import { useCallback } from 'react';
-import { useTaskSync } from '../../hooks/useTaskSync';
+import { Alert, AlertDescription, AlertTitle } from '../../components/ui/alert';
+import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
 import ExcelUploadCard from '../../features/taskSync/components/ExcelUploadCard';
 import NewTasksTableV2 from '../../features/taskSync/components/NewTasksTableV2';
+import { useTaskSync } from '../../hooks/useTaskSync';
 
 interface Props {
   listId: string;
@@ -36,26 +39,40 @@ function TaskSync({ listId }: Props) {
   }, [newMqmsRows, listId, syncAll, removeRowsByExternalId]);
 
   return (
-    <div className="w-full max-w-6xl mx-auto space-y-6">
+    <div className="space-y-8">
       <ExcelUploadCard setData={setMqmsRows} />
 
-      {loadingClickUp && <p className="text-sm text-zinc-400">Obteniendo datos de ClickUp…</p>}
-      {error && <p className="text-sm text-red-400">{error}</p>}
+      {loadingClickUp && (
+        <Alert variant="info">
+          <AlertTitle>Consultando ClickUp…</AlertTitle>
+          <AlertDescription>Obteniendo tareas existentes para evitar duplicados.</AlertDescription>
+        </Alert>
+      )}
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertTitle>Ocurrió un error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
 
       {newMqmsRows.length > 0 && (
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="text-base font-semibold">Tareas nuevas detectadas ({newMqmsRows.length})</h3>
-            <button
-              type="button"
-              onClick={handleSyncAll}
-              className="px-3 py-2 rounded-md bg-emerald-600 hover:bg-emerald-500 text-white text-sm"
-            >
+        <Card className="border-zinc-800/60">
+          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-1">
+              <CardTitle>Tareas nuevas detectadas</CardTitle>
+              <CardDescription>
+                {newMqmsRows.length} {newMqmsRows.length === 1 ? 'fila lista' : 'filas listas'} para sincronizar con ClickUp.
+              </CardDescription>
+            </div>
+            <Button onClick={handleSyncAll} className="w-full md:w-auto" disabled={newMqmsRows.length === 0}>
               Sincronizar todas
-            </button>
-          </div>
-          <NewTasksTableV2 rows={newMqmsRows} onSyncOne={handleSyncOne} />
-        </div>
+            </Button>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <NewTasksTableV2 rows={newMqmsRows} onSyncOne={handleSyncOne} />
+          </CardContent>
+        </Card>
       )}
     </div>
   );

--- a/src/pages/TaskSync/TaskSync.tsx
+++ b/src/pages/TaskSync/TaskSync.tsx
@@ -39,35 +39,47 @@ function TaskSync({ listId }: Props) {
   }, [newMqmsRows, listId, syncAll, removeRowsByExternalId]);
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-10">
       <ExcelUploadCard setData={setMqmsRows} />
 
       {loadingClickUp && (
-        <Alert variant="info">
+        <Alert variant="info" className="border-emerald-400/40 bg-emerald-500/15 text-emerald-100">
           <AlertTitle>Consultando ClickUp…</AlertTitle>
           <AlertDescription>Obteniendo tareas existentes para evitar duplicados.</AlertDescription>
         </Alert>
       )}
 
       {error && (
-        <Alert variant="destructive">
+        <Alert variant="destructive" className="border-red-500/60 bg-red-500/10 text-red-200">
           <AlertTitle>Ocurrió un error</AlertTitle>
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
 
       {newMqmsRows.length > 0 && (
-        <Card className="border-zinc-800/60">
-          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div className="space-y-1">
-              <CardTitle>Tareas nuevas detectadas</CardTitle>
-              <CardDescription>
-                {newMqmsRows.length} {newMqmsRows.length === 1 ? 'fila lista' : 'filas listas'} para sincronizar con ClickUp.
-              </CardDescription>
+        <Card className="border-slate-800/70 bg-slate-900/70 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.55)]">
+          <CardHeader className="gap-6">
+            <div className="flex flex-wrap items-center gap-3 text-[0.65rem] uppercase tracking-[0.35em] text-emerald-300">
+              <span className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-400/40 bg-emerald-400/10 text-xs font-semibold text-emerald-200">
+                PASO 3
+              </span>
+              <span className="font-semibold tracking-[0.28em] text-emerald-200">Valida y sincroniza</span>
             </div>
-            <Button onClick={handleSyncAll} className="w-full md:w-auto" disabled={newMqmsRows.length === 0}>
-              Sincronizar todas
-            </Button>
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-1 text-slate-100">
+                <CardTitle className="text-2xl font-semibold">Tareas nuevas detectadas</CardTitle>
+                <CardDescription className="text-sm text-slate-400">
+                  {newMqmsRows.length} {newMqmsRows.length === 1 ? 'fila lista' : 'filas listas'} para sincronizar con ClickUp.
+                </CardDescription>
+              </div>
+              <Button
+                onClick={handleSyncAll}
+                className="w-full md:w-auto"
+                disabled={newMqmsRows.length === 0}
+              >
+                Sincronizar todas
+              </Button>
+            </div>
           </CardHeader>
           <CardContent className="space-y-4">
             <NewTasksTableV2 rows={newMqmsRows} onSyncOne={handleSyncOne} />

--- a/src/pages/TaskSync/TaskSyncListSelector.tsx
+++ b/src/pages/TaskSync/TaskSyncListSelector.tsx
@@ -9,29 +9,39 @@ function TaskSyncListSelector() {
   const [listId, setListId] = useState<string | null>(null);
 
   return (
-    <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-12">
-      <div className="absolute inset-x-0 top-20 -z-10 mx-auto h-72 max-w-3xl rounded-full bg-emerald-500/10 blur-3xl" />
-      <div className="space-y-3 text-center">
-        <h1 className="text-3xl font-semibold tracking-tight text-zinc-50">Sincroniza MQMS con ClickUp</h1>
-        <p className="text-sm text-zinc-400">
-          Selecciona la lista adecuada, importa el Excel y sincroniza solo las tareas que aún no existen en ClickUp.
-        </p>
+    <div className="relative isolate overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-emerald-500/25 via-transparent to-transparent blur-3xl" />
+        <div className="absolute -left-32 top-48 h-80 w-80 rounded-full bg-emerald-500/15 blur-3xl" />
+        <div className="absolute -right-40 top-20 h-96 w-96 rounded-full bg-sky-500/10 blur-3xl" />
       </div>
 
-      <ListSelector main={main} setMain={setMain} bau={bau} setBau={setBau} onListResolved={setListId} />
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-16 lg:px-10">
+        <header className="mx-auto max-w-3xl text-center">
+          <p className="text-xs uppercase tracking-[0.4em] text-emerald-300">Task Sync</p>
+          <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-4xl">
+            Sincroniza MQMS con ClickUp sin perder contexto
+          </h1>
+          <p className="mt-4 text-base text-slate-400">
+            Elige la lista correcta, importa el Excel y valida qué tareas aún no existen en ClickUp antes de sincronizar.
+          </p>
+        </header>
 
-      {listId ? (
-        <TaskSync listId={listId} />
-      ) : (
-        <Alert className="border-zinc-800/60 bg-zinc-950/60">
-          <AlertTitle>Aún no hay una lista seleccionada</AlertTitle>
-          <AlertDescription>
-            {main === 'bau'
-              ? 'Selecciona un subtipo de BAU para habilitar la sincronización. '
-              : 'Elige High Split o BAU para comenzar.'}
-          </AlertDescription>
-        </Alert>
-      )}
+        <ListSelector main={main} setMain={setMain} bau={bau} setBau={setBau} onListResolved={setListId} />
+
+        {listId ? (
+          <TaskSync listId={listId} />
+        ) : (
+          <Alert className="border-slate-800/70 bg-slate-900/70 text-slate-200">
+            <AlertTitle>Aún no hay una lista seleccionada</AlertTitle>
+            <AlertDescription>
+              {main === 'bau'
+                ? 'Selecciona un subtipo de BAU para habilitar la sincronización.'
+                : 'Elige High Split o BAU para comenzar.'}
+            </AlertDescription>
+          </Alert>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/TaskSync/TaskSyncListSelector.tsx
+++ b/src/pages/TaskSync/TaskSyncListSelector.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '../../components/ui/alert';
 import ListSelector, { BauType, MainList } from '../../features/taskSync/components/ListSelector';
 import TaskSync from './TaskSync';
 
@@ -8,22 +9,28 @@ function TaskSyncListSelector() {
   const [listId, setListId] = useState<string | null>(null);
 
   return (
-    <div className="w-full px-4">
-      <ListSelector
-        main={main}
-        setMain={setMain}
-        bau={bau}
-        setBau={setBau}
-        onListResolved={setListId}
-      />
-      {listId ? (
-        <div className="mt-6">
-          <TaskSync listId={listId} />
-        </div>
-      ) : (
-        <p className="mt-6 text-center text-sm text-zinc-400">
-          Seleccione una lista{main === 'bau' ? ' y un tipo de BAU' : ''}
+    <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-12">
+      <div className="absolute inset-x-0 top-20 -z-10 mx-auto h-72 max-w-3xl rounded-full bg-emerald-500/10 blur-3xl" />
+      <div className="space-y-3 text-center">
+        <h1 className="text-3xl font-semibold tracking-tight text-zinc-50">Sincroniza MQMS con ClickUp</h1>
+        <p className="text-sm text-zinc-400">
+          Selecciona la lista adecuada, importa el Excel y sincroniza solo las tareas que aún no existen en ClickUp.
         </p>
+      </div>
+
+      <ListSelector main={main} setMain={setMain} bau={bau} setBau={setBau} onListResolved={setListId} />
+
+      {listId ? (
+        <TaskSync listId={listId} />
+      ) : (
+        <Alert className="border-zinc-800/60 bg-zinc-950/60">
+          <AlertTitle>Aún no hay una lista seleccionada</AlertTitle>
+          <AlertDescription>
+            {main === 'bau'
+              ? 'Selecciona un subtipo de BAU para habilitar la sincronización. '
+              : 'Elige High Split o BAU para comenzar.'}
+          </AlertDescription>
+        </Alert>
       )}
     </div>
   );

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,7 +1,5 @@
-import React from "react";
-import userEvent from "@testing-library/user-event";
-import { describe, test, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, test } from "vitest";
+import { render } from "@testing-library/react";
 import App from "../src/App.tsx";
 
 describe("<App />", () => {


### PR DESCRIPTION
## Summary
- introduce shadcn-inspired ui primitives (card, button, table, alert, etc.) to modernize styling
- refresh Task Sync list selector, upload card, table, and status messaging with new components
- clean up lint issues from unused types/imports in existing files

## Testing
- pnpm lint
- pnpm test -- --run

